### PR TITLE
Observe custom toJSON methods when stringify is called on a value

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,6 @@ The only difference is that `JSON5.stringify()` will avoid quoting keys where ap
 2. **replacer:** a transformer to run on each value (not supported, will throw an exception if used)
 3. **space:** Causes the resulting string to be pretty-printed.
 
-Another limitation is that the [`toJSON` behavior](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior)
-is not yet supported.
-
 ## Stringify example
 
 Using JSON5, you can stringify JS objects like this:
@@ -176,6 +173,9 @@ JSON5.stringify({first: 8, 'second key': 9}, function() {return 'nuthin';});
 
 JSON5.stringify({first: 8, 'second key': 9}, null, ' ');
 // => '{\n first: 8,\n "second key": 9\n}'
+
+JSON5.stringify({first: 8, toJSON:function(){ return {'second key': 9}; }}, null, ' ');
+// => '{\n "second key": 9\n}'
 ```
 When using JSON, all keys are quoted:
 
@@ -188,6 +188,9 @@ JSON.stringify({first: 8, 'second key': 9}, function() {return 'nuthin';});
 
 JSON.stringify({first: 8, 'second key': 9}, null, ' ');
 // => '{\n "first": 8,\n "second key": 9\n}'
+
+JSON.stringify({first: 8, toJSON:function(){ return {'second key': 9}; }}, null, ' ');
+// => '{\n "second key": 9\n}'
 ```
 
 ## Community

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -625,6 +625,9 @@ JSON5.stringify = function (obj, replacer, space) {
 
     function internalStringify(obj_part) {
         var buffer, res;
+        if (obj_part && obj_part['toJSON'] && typeof obj_part.toJSON === 'function') {
+            obj_part = obj_part.toJSON();
+        }
         if (obj_part && !isDate(obj_part)) {
             // unbox objects
             // don't unbox dates, since will turn it into number
@@ -646,8 +649,6 @@ JSON5.stringify = function (obj, replacer, space) {
             case "object":
                 if (obj_part === null) {
                     return "null";
-                } else if (isDate(obj_part)) {
-                    return escapeString(obj_part.toJSON());
                 } else if (isArray(obj_part)) {
                     checkForCircular(obj_part);
                     buffer = "[";


### PR DESCRIPTION
Hi,

This PR addresses issue #39, observing toJSON in stringify() calls.

Happily, this means stringify() no longer needs to special-case Date objects: their toJSON function gets called like everything else.

Note also that even if the result of toJSON() has a toJSON function itself, that second function isn't called, apparently. I've put a test in for that case.

I've also updated the README.md to remove the text saying toJSON isn't supported and added a toJSON-based stringify() example.

Thanks,
Rowan
