### PR TITLE
Standardise whitespace to four spaces, not tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
     (second parameter)
     * does not respect the [`toJSON` method of objects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify?redirectlocale=en-US&redirectslug=JavaScript%2FReference%2FGlobal_Objects%2FJSON%2Fstringify#toJSON_behavior)
     to be converted
-		
+
 [#36]: https://github.com/aseemk/json5/pull/35
 
 ### v0.2.0 [[code][c0.2.0], [diff][d0.2.0]]

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -502,112 +502,112 @@ JSON5.parse = (function () {
 // JSON5 stringify will not quote keys where appropriate
 JSON5.stringify = function (obj, replacer, space) {
 
-	if (replacer) {
-		throw new Error('JSON5 does not support the replacer parameter. Use JSON instead.');
-	}
+    if (replacer) {
+        throw new Error('JSON5 does not support the replacer parameter. Use JSON instead.');
+    }
 
-	function isWordChar(char) {
-		return (char >= 'a' && char <= 'z') ||
-			(char >= 'A' && char <= 'Z') ||
-			(char >= '0' && char <= '9') ||
-			char === '_' || char === '$';
-	}
+    function isWordChar(char) {
+        return (char >= 'a' && char <= 'z') ||
+            (char >= 'A' && char <= 'Z') ||
+            (char >= '0' && char <= '9') ||
+            char === '_' || char === '$';
+    }
 
-	function isWordStart(char) {
-		return (char >= 'a' && char <= 'z') ||
-			(char >= 'A' && char <= 'Z') ||
-			char === '_' || char === '$';
-	}
+    function isWordStart(char) {
+        return (char >= 'a' && char <= 'z') ||
+            (char >= 'A' && char <= 'Z') ||
+            char === '_' || char === '$';
+    }
 
-	function isWord(key) {
-		if (typeof key !== 'string') {
-			return false;
-		}
-		if (!isWordStart(key[0])) {
-			return false;
-		}
-		var i = 1, length = key.length;
-		while (i < length) {
-			if (!isWordChar(key[i])) {
-				return false;
-			}
-			i++;
-		}
-		return true;
-	}
+    function isWord(key) {
+        if (typeof key !== 'string') {
+            return false;
+        }
+        if (!isWordStart(key[0])) {
+            return false;
+        }
+        var i = 1, length = key.length;
+        while (i < length) {
+            if (!isWordChar(key[i])) {
+                return false;
+            }
+            i++;
+        }
+        return true;
+    }
 
-	// export for use in tests
-	JSON5.isWord = isWord;
+    // export for use in tests
+    JSON5.isWord = isWord;
 
-	// polyfills
-	function isArray(obj) {
-		if (Array.isArray) {
-			return Array.isArray(obj);
-		} else {
-			return Object.prototype.toString.call(obj) === '[object Array]';
-		}
-	}
+    // polyfills
+    function isArray(obj) {
+        if (Array.isArray) {
+            return Array.isArray(obj);
+        } else {
+            return Object.prototype.toString.call(obj) === '[object Array]';
+        }
+    }
 
-	function isDate(obj) {
-		return Object.prototype.toString.call(obj) === '[object Date]';
-	}
+    function isDate(obj) {
+        return Object.prototype.toString.call(obj) === '[object Date]';
+    }
 
-	isNaN = isNaN || function(val) {
-		return typeof val === 'number' && val !== val;
-	};
+    isNaN = isNaN || function(val) {
+        return typeof val === 'number' && val !== val;
+    };
 
-	var objStack = [];
-	function checkForCircular(obj) {
-		for (var i = 0; i < objStack.length; i++) {
-			if (objStack[i] === obj) {
-				throw new TypeError("Converting circular structure to JSON");
-			}
-		}
-	}
+    var objStack = [];
+    function checkForCircular(obj) {
+        for (var i = 0; i < objStack.length; i++) {
+            if (objStack[i] === obj) {
+                throw new TypeError("Converting circular structure to JSON");
+            }
+        }
+    }
 
-	function makeIndent(str, num, noNewLine) {
-		if (!str) {
-			return "";
-		}
-		// indentation no more than 10 chars
-		if (str.length > 10) {
-			str = str.substring(0, 10);
-		}
+    function makeIndent(str, num, noNewLine) {
+        if (!str) {
+            return "";
+        }
+        // indentation no more than 10 chars
+        if (str.length > 10) {
+            str = str.substring(0, 10);
+        }
 
-		var indent = noNewLine ? "" : "\n";
-		for (var i = 0; i < num; i++) {
-			indent += str;
-		}
+        var indent = noNewLine ? "" : "\n";
+        for (var i = 0; i < num; i++) {
+            indent += str;
+        }
 
-		return indent;
-	}
+        return indent;
+    }
 
-	var indentStr;
-	if (space) {
-		if (typeof space === "string") {
-			indentStr = space;
-		} else if (typeof space === "number" && space >= 0) {
-			indentStr = makeIndent(" ", space, true);
-		} else {
-			// ignore space parameter
-		}
-	}
+    var indentStr;
+    if (space) {
+        if (typeof space === "string") {
+            indentStr = space;
+        } else if (typeof space === "number" && space >= 0) {
+            indentStr = makeIndent(" ", space, true);
+        } else {
+            // ignore space parameter
+        }
+    }
 
-	// Copied from Crokford's implementation of JSON
-	// See https://github.com/douglascrockford/JSON-js/blob/e39db4b7e6249f04a195e7dd0840e610cc9e941e/json2.js#L195
-	// Begin
+    // Copied from Crokford's implementation of JSON
+    // See https://github.com/douglascrockford/JSON-js/blob/e39db4b7e6249f04a195e7dd0840e610cc9e941e/json2.js#L195
+    // Begin
     var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
         escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
-		meta = { // table of character substitutions
-		'\b': '\\b',
-		'\t': '\\t',
-		'\n': '\\n',
-		'\f': '\\f',
-		'\r': '\\r',
-		'"' : '\\"',
-		'\\': '\\\\'
+        meta = { // table of character substitutions
+        '\b': '\\b',
+        '\t': '\\t',
+        '\n': '\\n',
+        '\f': '\\f',
+        '\r': '\\r',
+        '"' : '\\"',
+        '\\': '\\\\'
     };
-	function escapeString(string) {
+    function escapeString(string) {
 
 // If the string contains no control characters, no quote characters, and no
 // backslash characters, then we can safely slap some quotes around it.
@@ -623,87 +623,87 @@ JSON5.stringify = function (obj, replacer, space) {
     }
     // End
 
-	function internalStringify(obj_part) {
-		var buffer, res;
-		if (obj_part && !isDate(obj_part)) {
-			// unbox objects
-			// don't unbox dates, since will turn it into number
-			obj_part = obj_part.valueOf();
-		}
-		switch(typeof obj_part) {
-			case "boolean":
-				return obj_part.toString();
+    function internalStringify(obj_part) {
+        var buffer, res;
+        if (obj_part && !isDate(obj_part)) {
+            // unbox objects
+            // don't unbox dates, since will turn it into number
+            obj_part = obj_part.valueOf();
+        }
+        switch(typeof obj_part) {
+            case "boolean":
+                return obj_part.toString();
 
-			case "number":
-				if (isNaN(obj_part) || !isFinite(obj_part)) {
-					return "null";
-				}
-				return obj_part.toString();
+            case "number":
+                if (isNaN(obj_part) || !isFinite(obj_part)) {
+                    return "null";
+                }
+                return obj_part.toString();
 
-			case "string":
-				return escapeString(obj_part.toString());
+            case "string":
+                return escapeString(obj_part.toString());
 
-			case "object":
-				if (obj_part === null) {
-					return "null";
-				} else if (isDate(obj_part)) {
-					return escapeString(obj_part.toJSON());
-				} else if (isArray(obj_part)) {
-					checkForCircular(obj_part);
-					buffer = "[";
-					objStack.push(obj_part);
+            case "object":
+                if (obj_part === null) {
+                    return "null";
+                } else if (isDate(obj_part)) {
+                    return escapeString(obj_part.toJSON());
+                } else if (isArray(obj_part)) {
+                    checkForCircular(obj_part);
+                    buffer = "[";
+                    objStack.push(obj_part);
 
-					for (var i = 0; i < obj_part.length; i++) {
-						res = internalStringify(obj_part[i]);
-						buffer += makeIndent(indentStr, objStack.length);
-						if (res === null || typeof res === "undefined") {
-							buffer += "null";
-						} else {
-							buffer += res;
-						}
-						if (i < obj_part.length-1) {
-							buffer += ",";
-						} else if (indentStr) {
-							buffer += "\n";
-						}
-					}
-					objStack.pop();
-					buffer += makeIndent(indentStr, objStack.length, true) + "]";
-				} else {
-					checkForCircular(obj_part);
-					buffer = "{";
-					var nonEmpty = false;
-					objStack.push(obj_part);
-					for (var prop in obj_part) {
-						if (obj_part.hasOwnProperty(prop)) {
-							var value = internalStringify(obj_part[prop]);
-							if (typeof value !== "undefined" && value !== null) {
-								buffer += makeIndent(indentStr, objStack.length);
-								nonEmpty = true;
-								var key = isWord(prop) ? prop : escapeString(prop);
-								buffer += key + ":" + (indentStr ? ' ' : '') + value + ",";
-							}
-						}
-					}
-					objStack.pop();
-					if (nonEmpty) {
-						buffer = buffer.substring(0, buffer.length-1) + makeIndent(indentStr, objStack.length) + "}";
-					} else {
-						buffer = '{}';
-					}
-				}
-				return buffer;
-			default:
-				// functions and undefined should be ignored
-				return undefined;
-		}
-	}
+                    for (var i = 0; i < obj_part.length; i++) {
+                        res = internalStringify(obj_part[i]);
+                        buffer += makeIndent(indentStr, objStack.length);
+                        if (res === null || typeof res === "undefined") {
+                            buffer += "null";
+                        } else {
+                            buffer += res;
+                        }
+                        if (i < obj_part.length-1) {
+                            buffer += ",";
+                        } else if (indentStr) {
+                            buffer += "\n";
+                        }
+                    }
+                    objStack.pop();
+                    buffer += makeIndent(indentStr, objStack.length, true) + "]";
+                } else {
+                    checkForCircular(obj_part);
+                    buffer = "{";
+                    var nonEmpty = false;
+                    objStack.push(obj_part);
+                    for (var prop in obj_part) {
+                        if (obj_part.hasOwnProperty(prop)) {
+                            var value = internalStringify(obj_part[prop]);
+                            if (typeof value !== "undefined" && value !== null) {
+                                buffer += makeIndent(indentStr, objStack.length);
+                                nonEmpty = true;
+                                var key = isWord(prop) ? prop : escapeString(prop);
+                                buffer += key + ":" + (indentStr ? ' ' : '') + value + ",";
+                            }
+                        }
+                    }
+                    objStack.pop();
+                    if (nonEmpty) {
+                        buffer = buffer.substring(0, buffer.length-1) + makeIndent(indentStr, objStack.length) + "}";
+                    } else {
+                        buffer = '{}';
+                    }
+                }
+                return buffer;
+            default:
+                // functions and undefined should be ignored
+                return undefined;
+        }
+    }
 
-	// special case...when undefined is used inside of
-	// a compound object/array, return null.
-	// but when top-level, return undefined
-	if (obj === undefined) {
-		return undefined;
-	}
+    // special case...when undefined is used inside of
+    // a compound object/array, return null.
+    // but when top-level, return undefined
+    if (obj === undefined) {
+        return undefined;
+    }
     return internalStringify(obj, replacer, space);
 };

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -14,240 +14,240 @@ var JSON5 = require('../lib/json5');
 
 exports.stringify = {};
 exports.stringify.simple = function test() {
-	assertStringify();
-	assertStringify(null);
-	assertStringify(9);
-	assertStringify(-9);
-	assertStringify(+9);
-	assertStringify(+9.878);
-	assertStringify('');
-	assertStringify("''");
-	assertStringify('999');
-	assertStringify('9aa');
-	assertStringify('aaa');
-	assertStringify('aa a');
-	assertStringify('aa\na');
-	assertStringify('aa\\a');
-	assertStringify('\'');
-	assertStringify('\\\'');
-	assertStringify('\\"');
-	assertStringify(undefined);
-	assertStringify(true);
-	assertStringify(false);
-	assertStringify({});
-	assertStringify([]);
-	assertStringify(function() {});
-	assertStringify(Date.now());
-	assertStringify(new Date(Date.now()));
-};	
+    assertStringify();
+    assertStringify(null);
+    assertStringify(9);
+    assertStringify(-9);
+    assertStringify(+9);
+    assertStringify(+9.878);
+    assertStringify('');
+    assertStringify("''");
+    assertStringify('999');
+    assertStringify('9aa');
+    assertStringify('aaa');
+    assertStringify('aa a');
+    assertStringify('aa\na');
+    assertStringify('aa\\a');
+    assertStringify('\'');
+    assertStringify('\\\'');
+    assertStringify('\\"');
+    assertStringify(undefined);
+    assertStringify(true);
+    assertStringify(false);
+    assertStringify({});
+    assertStringify([]);
+    assertStringify(function() {});
+    assertStringify(Date.now());
+    assertStringify(new Date(Date.now()));
+};    
 
 exports.stringify.oddities = function test() {
-	assertStringify(Function);
-	assertStringify(Date);
-	assertStringify(Object);
-	assertStringify(NaN);
-	assertStringify(Infinity);
-	assertStringify(10e6);
-	assertStringify(19.3223e6);
-	assertStringify(077);
-	assertStringify(0x99);
-	assertStringify(/aa/);
-	assertStringify(new RegExp('aa'));
-	
-	assertStringify(new Number(7));
-	assertStringify(new String(7));
-	assertStringify(new String(""));
-	assertStringify(new String("abcde"));
-	assertStringify(new String(new String("abcde")));
-	assertStringify(new Boolean(true));
-	assertStringify(new Boolean());
+    assertStringify(Function);
+    assertStringify(Date);
+    assertStringify(Object);
+    assertStringify(NaN);
+    assertStringify(Infinity);
+    assertStringify(10e6);
+    assertStringify(19.3223e6);
+    assertStringify(077);
+    assertStringify(0x99);
+    assertStringify(/aa/);
+    assertStringify(new RegExp('aa'));
+    
+    assertStringify(new Number(7));
+    assertStringify(new String(7));
+    assertStringify(new String(""));
+    assertStringify(new String("abcde"));
+    assertStringify(new String(new String("abcde")));
+    assertStringify(new Boolean(true));
+    assertStringify(new Boolean());
 };
 
 exports.stringify.arrays = function test() {
-	assertStringify([""]);
-	assertStringify([1, 2]);
-	assertStringify([undefined]);
-	assertStringify([1, 'fasds']);
-	assertStringify([1, '\n\b\t\f\r\'']);
-	assertStringify([1, 'fasds', ['fdsafsd'], null]);
-	assertStringify([1, 'fasds', ['fdsafsd'], null, function(aaa) { return 1; }, false ]);
-	assertStringify([1, 'fasds', ['fdsafsd'], undefined, function(aaa) { return 1; }, false ]);
+    assertStringify([""]);
+    assertStringify([1, 2]);
+    assertStringify([undefined]);
+    assertStringify([1, 'fasds']);
+    assertStringify([1, '\n\b\t\f\r\'']);
+    assertStringify([1, 'fasds', ['fdsafsd'], null]);
+    assertStringify([1, 'fasds', ['fdsafsd'], null, function(aaa) { return 1; }, false ]);
+    assertStringify([1, 'fasds', ['fdsafsd'], undefined, function(aaa) { return 1; }, false ]);
 };
 
 exports.stringify.objects = function test() {
-	assertStringify({a:1, b:2});
-	assertStringify({"":1, b:2});
-	assertStringify({9:1, b:2});
-	assertStringify({"9aaa":1, b:2});
-	assertStringify({aaaa:1, bbbb:2});
-	assertStringify({a$a_aa:1, bbbb:2});
-	assertStringify({"a$a_aa":1, 'bbbb':2});
-	assertStringify({"a$a_aa":[1], 'bbbb':{a:2}});
-	assertStringify({"a$22222_aa":[1], 'bbbb':{aaaa:2, name:function(a,n,fh,h) { return 'nuthin'; }, foo: undefined}});
-	assertStringify({"a$222222_aa":[1], 'bbbb':{aaaa:2, name:'other', foo: undefined}});
-	assertStringify({"a$222222_aa":[1, {}, undefined, function() { }, { jjj: function() { } }], 'bbbb':{aaaa:2, name:'other', foo: undefined}});
-	
-	// using same obj multiple times
-	var innerObj = {a: 9, b:6};
-	assertStringify({a : innerObj, b: innerObj, c: [innerObj, innerObj, innerObj]});
+    assertStringify({a:1, b:2});
+    assertStringify({"":1, b:2});
+    assertStringify({9:1, b:2});
+    assertStringify({"9aaa":1, b:2});
+    assertStringify({aaaa:1, bbbb:2});
+    assertStringify({a$a_aa:1, bbbb:2});
+    assertStringify({"a$a_aa":1, 'bbbb':2});
+    assertStringify({"a$a_aa":[1], 'bbbb':{a:2}});
+    assertStringify({"a$22222_aa":[1], 'bbbb':{aaaa:2, name:function(a,n,fh,h) { return 'nuthin'; }, foo: undefined}});
+    assertStringify({"a$222222_aa":[1], 'bbbb':{aaaa:2, name:'other', foo: undefined}});
+    assertStringify({"a$222222_aa":[1, {}, undefined, function() { }, { jjj: function() { } }], 'bbbb':{aaaa:2, name:'other', foo: undefined}});
+    
+    // using same obj multiple times
+    var innerObj = {a: 9, b:6};
+    assertStringify({a : innerObj, b: innerObj, c: [innerObj, innerObj, innerObj]});
 };
 
 exports.stringify.oddKeys = function test() {
-	assertStringify({"this is a crazy long key":1, 'bbbb':2});
-	assertStringify({"":1, 'bbbb':2});
-	assertStringify({"s\ns":1, 'bbbb':2});
-	assertStringify({'\n\b\t\f\r\'\\':1, 'bbbb':2});
-	assertStringify({undefined:1, 'bbbb':2});
-	assertStringify({'\x00':'\x00'});
+    assertStringify({"this is a crazy long key":1, 'bbbb':2});
+    assertStringify({"":1, 'bbbb':2});
+    assertStringify({"s\ns":1, 'bbbb':2});
+    assertStringify({'\n\b\t\f\r\'\\':1, 'bbbb':2});
+    assertStringify({undefined:1, 'bbbb':2});
+    assertStringify({'\x00':'\x00'});
 };
 
 // we expect errors from all of these tests.  The errors should match
 exports.stringify.circular = function test() {
-	var obj = { };
-	obj.obj = obj;
-	assertStringify(obj, true);
-	
-	var obj2 = {inner1: {inner2: {}}};
-	obj2.inner1.inner2.obj = obj2;
-	assertStringify(obj2, true);
+    var obj = { };
+    obj.obj = obj;
+    assertStringify(obj, true);
+    
+    var obj2 = {inner1: {inner2: {}}};
+    obj2.inner1.inner2.obj = obj2;
+    assertStringify(obj2, true);
 
-	var obj3 = {inner1: {inner2: []}};
-	obj3.inner1.inner2[0] = obj3;
-	assertStringify(obj3, true);
+    var obj3 = {inner1: {inner2: []}};
+    obj3.inner1.inner2[0] = obj3;
+    assertStringify(obj3, true);
 };
 
 function stringifyJSON5(obj, reviver, space) {
-	var start, res, end;
-	try {
-		start = new Date();
-		res = JSON5.stringify(obj, null, space);
-		end = new Date();
-	} catch (e) {
-		res = e.message;
-		end = new Date();
-	}
-	if (DEBUG) {
-		console.log('JSON5.stringify time: ' + (end-start));
-		console.log(res);
-	}
-	return res;
+    var start, res, end;
+    try {
+        start = new Date();
+        res = JSON5.stringify(obj, null, space);
+        end = new Date();
+    } catch (e) {
+        res = e.message;
+        end = new Date();
+    }
+    if (DEBUG) {
+        console.log('JSON5.stringify time: ' + (end-start));
+        console.log(res);
+    }
+    return res;
 }
 
 function stringifyJSON(obj, reviver, space) {
-	var start, res, end;
-	
-	try {
-		start = new Date();
-		res = JSON.stringify(obj, null, space);
-		end = new Date();
-	
-		// now remove all quotes from keys where appropriate
-		// first recursively find all key names
-		var keys = [];
-		function findKeys(innerObj) {
-			if (typeof innerObj === 'object') {
-				if (innerObj === null) {
-					return;
-				} else if (Array.isArray(innerObj)) {
-					for (var i = 0; i < innerObj.length; i++) {
-						findKeys(innerObj[i]);
-					}
-				} else {
-					for (var prop in innerObj) {
-						if (innerObj.hasOwnProperty(prop)) {
-							if (JSON5.isWord(prop) &&
-								typeof innerObj[prop] !== 'function' &&
-								typeof innerObj[prop] !== 'undefined') {
-								keys.push(prop);
-								findKeys(innerObj[prop]);
-							}
-						}
-					}
-				}
-			}
-		}
-		findKeys(obj);
-		
-		// now replace each key in the result
-		var last = 0;
-		for (var i = 0; i < keys.length; i++) {
-		
-			// not perfect since we can match on parts of the previous value that 
-			// matches the key, but we can design our test around that.
-			last = res.indexOf('"' + keys[i] + '"', last);
-			if (last === -1) {
-				// problem with test framework
-				console.log("Couldn't find: " + keys[i]);
-				throw new Error("Couldn't find: " + keys[i]);
-			}
-			res = res.substring(0, last) + 
-				res.substring(last+1, last + keys[i].length+1) + 
-				res.substring(last + keys[i].length + 2, res.length);
-			last += keys[i].length;
-		}
-	} catch (e) {
-		res = e.message;
-		end = new Date();
-	}
-	if (DEBUG) {
-		console.log('JSON.stringify time: ' + (end-start));
-	}
-	return res;
+    var start, res, end;
+    
+    try {
+        start = new Date();
+        res = JSON.stringify(obj, null, space);
+        end = new Date();
+    
+        // now remove all quotes from keys where appropriate
+        // first recursively find all key names
+        var keys = [];
+        function findKeys(innerObj) {
+            if (typeof innerObj === 'object') {
+                if (innerObj === null) {
+                    return;
+                } else if (Array.isArray(innerObj)) {
+                    for (var i = 0; i < innerObj.length; i++) {
+                        findKeys(innerObj[i]);
+                    }
+                } else {
+                    for (var prop in innerObj) {
+                        if (innerObj.hasOwnProperty(prop)) {
+                            if (JSON5.isWord(prop) &&
+                                typeof innerObj[prop] !== 'function' &&
+                                typeof innerObj[prop] !== 'undefined') {
+                                keys.push(prop);
+                                findKeys(innerObj[prop]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        findKeys(obj);
+        
+        // now replace each key in the result
+        var last = 0;
+        for (var i = 0; i < keys.length; i++) {
+        
+            // not perfect since we can match on parts of the previous value that 
+            // matches the key, but we can design our test around that.
+            last = res.indexOf('"' + keys[i] + '"', last);
+            if (last === -1) {
+                // problem with test framework
+                console.log("Couldn't find: " + keys[i]);
+                throw new Error("Couldn't find: " + keys[i]);
+            }
+            res = res.substring(0, last) + 
+                res.substring(last+1, last + keys[i].length+1) + 
+                res.substring(last + keys[i].length + 2, res.length);
+            last += keys[i].length;
+        }
+    } catch (e) {
+        res = e.message;
+        end = new Date();
+    }
+    if (DEBUG) {
+        console.log('JSON.stringify time: ' + (end-start));
+    }
+    return res;
 }
 
 function assertStringify(obj, expectError) {
-	var j5, j;
-	
-	j5 = stringifyJSON5(obj);
-	j = stringifyJSON(obj);
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, " ");
-	j = stringifyJSON(obj, null, " ");
-	assert.equal(j5, j);
-	
-	// max 10 a spaces
-	j5 = stringifyJSON5(obj, null, "          ");
-	j = stringifyJSON(obj, null, "          ");
-	assert.equal(j5, j);
-	
-	// max 10 a spaces
-	j5 = stringifyJSON5(obj, null, "                    ");
-	j = stringifyJSON(obj, null, "                    ");
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, "\t");
-	j = stringifyJSON(obj, null, "\t");
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, "this is an odd indent");
-	j = stringifyJSON(obj, null, "this is an odd indent");
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, 5);
-	j = stringifyJSON(obj, null, 5);
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, 20);
-	j = stringifyJSON(obj, null, 20);
-	assert.equal(j5, j);
-	
-	j5 = stringifyJSON5(obj, null, '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t');
-	j = stringifyJSON(obj, null, '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t');
-	assert.equal(j5, j);
-	
-	if (!expectError) {
-		// no point in round tripping if there is an error
-		var origStr = JSON5.stringify(obj), roundTripStr;
-		if (origStr !== "undefined" && typeof origStr !== "undefined") {
-			try {
-				roundTripStr = JSON5.stringify(JSON5.parse(origStr));
-			} catch (e) {
-				console.log(e);
-				console.log(origStr);	
-				throw e;
-			}
-			assert.equal(origStr, roundTripStr);
-		}
-	}
+    var j5, j;
+    
+    j5 = stringifyJSON5(obj);
+    j = stringifyJSON(obj);
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, " ");
+    j = stringifyJSON(obj, null, " ");
+    assert.equal(j5, j);
+    
+    // max 10 a spaces
+    j5 = stringifyJSON5(obj, null, "          ");
+    j = stringifyJSON(obj, null, "          ");
+    assert.equal(j5, j);
+    
+    // max 10 a spaces
+    j5 = stringifyJSON5(obj, null, "                    ");
+    j = stringifyJSON(obj, null, "                    ");
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, "\t");
+    j = stringifyJSON(obj, null, "\t");
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, "this is an odd indent");
+    j = stringifyJSON(obj, null, "this is an odd indent");
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, 5);
+    j = stringifyJSON(obj, null, 5);
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, 20);
+    j = stringifyJSON(obj, null, 20);
+    assert.equal(j5, j);
+    
+    j5 = stringifyJSON5(obj, null, '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t');
+    j = stringifyJSON(obj, null, '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t');
+    assert.equal(j5, j);
+    
+    if (!expectError) {
+        // no point in round tripping if there is an error
+        var origStr = JSON5.stringify(obj), roundTripStr;
+        if (origStr !== "undefined" && typeof origStr !== "undefined") {
+            try {
+                roundTripStr = JSON5.stringify(JSON5.parse(origStr));
+            } catch (e) {
+                console.log(e);
+                console.log(origStr);    
+                throw e;
+            }
+            assert.equal(origStr, roundTripStr);
+        }
+    }
 }


### PR DESCRIPTION
Hi,

Me again - just a quick whitespace standardisation, as I'd noticed whilst putting in my other PRs that the source files were a mix of tabs and spaces.

I've converted to spaces because a) they seemed more popular in the codebase and b) [Crockford said to](http://javascript.crockford.com/code.html#indentation) :).

Note: this will conflict with my other pull requests, but I'll happily rebase once these start getting merged. If you want to merge this one whilst you mull over the other ones, I'll rebase whilst you're considering them.

Thanks,
Rowan
