### PR TITLE
Fix Travis CI Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - 0.6
   - 0.8
-  - 0.9
+  - 0.10


### PR DESCRIPTION
Node version 0.9 is [not supported](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Provided-Node.js-Versions), but 0.10 is.
