### PR TITLE
Adding a --validate CLI option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,13 +12,15 @@ var Path = require('path');
 
 var USAGE = [
     'Usage: json5 -c path/to/file.json5 ...',
-    'Compiles JSON5 files into sibling JSON files with the same basenames.',
+    '    Compiles JSON5 files into sibling JSON files with the same basenames.',
+    'or:  json5 --validate path/to/file.json5 ...',
+    '    Validates JSON5 files'
 ].join('\n');
 
-// if valid, args look like [node, json5, -c, file1, file2, ...]
+// if valid, args look like [node, json5, -c || -t, file1, file2, ...]
 var args = process.argv;
 
-if (args.length < 4 || args[2] !== '-c') {
+if (args[2] === '-c' || args[2] === '--validate' && args.length < 4) {
     console.error(USAGE);
     process.exit(1);
 }
@@ -34,8 +36,13 @@ files.forEach(function (file) {
 
     var json5 = FS.readFileSync(path, 'utf8');
     var obj = JSON5.parse(json5);
-    var json = JSON.stringify(obj, null, 4); // 4 spaces; TODO configurable?
+    // if we are here for validation, we'll just output things are OK.
+    if(args[2] === '--validate') {
+      console.log('\t\x1b[32;1m' + file + ' is valid.\x1b[0m');
+    } else {
+      var json = JSON.stringify(obj, null, 4); // 4 spaces; TODO configurable?
 
-    path = Path.join(dirname, basename + '.json');
-    FS.writeFileSync(path, json, 'utf8');
+      path = Path.join(dirname, basename + '.json');
+      FS.writeFileSync(path, json, 'utf8');
+    }
 });


### PR DESCRIPTION
Simple version of a `--validate` option for the CLI added by highjacking the `-c` option code.

Sort-of delivers #72 
