### PR TITLE
Move isWord function to its own module

### DIFF
--- a/dist/json5.js
+++ b/dist/json5.js
@@ -1,3 +1,39 @@
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.JSON5 = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+"use strict";
+
+function isWordChar(char) {
+    return (char >= 'a' && char <= 'z') ||
+        (char >= 'A' && char <= 'Z') ||
+        (char >= '0' && char <= '9') ||
+        char === '_' || char === '$';
+}
+
+function isWordStart(char) {
+    return (char >= 'a' && char <= 'z') ||
+        (char >= 'A' && char <= 'Z') ||
+        char === '_' || char === '$';
+}
+
+function isWord(key) {
+    if (typeof key !== 'string') {
+        return false;
+    }
+    if (!isWordStart(key[0])) {
+        return false;
+    }
+    var i = 1, length = key.length;
+    while (i < length) {
+        if (!isWordChar(key[i])) {
+            return false;
+        }
+        i++;
+    }
+    return true;
+}
+
+module.exports = isWord;
+
+},{}],2:[function(require,module,exports){
 // json5.js
 // Modern JSON. See README.md for details.
 //
@@ -194,7 +230,7 @@ JSON5.parse = (function () {
             } else {
                 number = +string;
             }
-            
+
             if (!isFinite(number)) {
                 error("Bad number");
             } else {
@@ -721,3 +757,6 @@ JSON5.stringify = function (obj, replacer, space) {
     }
     return internalStringify(topLevelHolder, '', true);
 };
+
+},{"./is-word":1}]},{},[2])(2)
+});

--- a/lib/is-word.js
+++ b/lib/is-word.js
@@ -1,0 +1,33 @@
+"use strict";
+
+function isWordChar(char) {
+    return (char >= 'a' && char <= 'z') ||
+        (char >= 'A' && char <= 'Z') ||
+        (char >= '0' && char <= '9') ||
+        char === '_' || char === '$';
+}
+
+function isWordStart(char) {
+    return (char >= 'a' && char <= 'z') ||
+        (char >= 'A' && char <= 'Z') ||
+        char === '_' || char === '$';
+}
+
+function isWord(key) {
+    if (typeof key !== 'string') {
+        return false;
+    }
+    if (!isWordStart(key[0])) {
+        return false;
+    }
+    var i = 1, length = key.length;
+    while (i < length) {
+        if (!isWordChar(key[i])) {
+            return false;
+        }
+        i++;
+    }
+    return true;
+}
+
+module.exports = isWord;

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -4,6 +4,8 @@
 // This file is based directly off of Douglas Crockford's json_parse.js:
 // https://github.com/douglascrockford/JSON-js/blob/master/json_parse.js
 
+var isWord = require('./is-word');
+
 var JSON5 = (typeof exports === 'object' ? exports : {});
 
 JSON5.parse = (function () {
@@ -546,39 +548,6 @@ JSON5.stringify = function (obj, replacer, space) {
             return value;
         }
     };
-
-    function isWordChar(char) {
-        return (char >= 'a' && char <= 'z') ||
-            (char >= 'A' && char <= 'Z') ||
-            (char >= '0' && char <= '9') ||
-            char === '_' || char === '$';
-    }
-
-    function isWordStart(char) {
-        return (char >= 'a' && char <= 'z') ||
-            (char >= 'A' && char <= 'Z') ||
-            char === '_' || char === '$';
-    }
-
-    function isWord(key) {
-        if (typeof key !== 'string') {
-            return false;
-        }
-        if (!isWordStart(key[0])) {
-            return false;
-        }
-        var i = 1, length = key.length;
-        while (i < length) {
-            if (!isWordChar(key[i])) {
-                return false;
-            }
-            i++;
-        }
-        return true;
-    }
-
-    // export for use in tests
-    JSON5.isWord = isWord;
 
     // polyfills
     function isArray(obj) {

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "bin": "lib/cli.js",
     "dependencies": {},
     "devDependencies": {
-        "mocha": "~1.0.3"
+        "mocha": "~1.0.3",
+        "browserify": "~10.2.4"
     },
     "scripts": {
-        "build": "./lib/cli.js -c package.json5",
+        "build": "./lib/cli.js -c package.json5 && browserify -s JSON5 lib/json5.js >dist/json5.js",
         "test": "mocha --ui exports --reporter spec"
     },
     "homepage": "http://json5.org/",

--- a/package.json5
+++ b/package.json5
@@ -19,9 +19,10 @@
     dependencies: {},
     devDependencies: {
         mocha: '~1.0.3',    // TODO: Look into Mocha v2.
+        browserify: '~10.2.4',
     },
     scripts: {
-        build: './lib/cli.js -c package.json5',
+        build: './lib/cli.js -c package.json5 && browserify -s JSON5 lib/json5.js >dist/json5.js',
         test: 'mocha --ui exports --reporter spec',
             // TODO: Would it be better to define these in a mocha.opts file?
     },

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -7,6 +7,7 @@ var DEBUG = false;
 
 var assert = require('assert');
 var JSON5 = require('../lib/json5');
+var isWord = require('../lib/is-word');
 
 // Test JSON5.stringify() by comparing its output for each case with 
 // native JSON.stringify().  The only differences will be in how object keys are 
@@ -402,7 +403,7 @@ function stringifyJSON(obj, replacer, space) {
                     return;
                 }
             }
-            if (JSON5.isWord(key) &&
+            if (isWord(key) &&
                 typeof innerObj !== 'function' &&
                 typeof innerObj !== 'undefined') {
                 keys.push(key);


### PR DESCRIPTION
`isWord` property is [introduced](https://github.com/aseemk/json5/blob/1d54c2c98bc8a2b4cf02b05297d4898cc65df105/lib/json5.js#L580) on purpose on JSON5 object after `JSON5.stringify` call to facilitate testing.

This patch moves `isWord` and supporting functions to its own module `lib/is-word.js` and fixes this leakage. This obviously breaks using `json5.js` in the browser so I added browserify for making UMD builds at `dist/json5.js`.

Close #68.
