### PR TITLE
- Adding @'include' and recurse check

### DIFF
--- a/lib/json5.js
+++ b/lib/json5.js
@@ -11,6 +11,7 @@ var inNode = (typeof module !== 'undefined' && module.exports);
 JSON5.parse = (function () {
     "use strict";
     var fs = inNode?require('fs'):null;
+    var includes = [];
 
 // This is a function that can parse a JSON5 text, producing a JavaScript
 // data structure. It is a simple, recursive descent parser. It does not use
@@ -58,7 +59,11 @@ JSON5.parse = (function () {
 
             var error = new SyntaxError();
             // beginning of message suffix to agree with that provided by Gecko - see https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-            error.message = m + " at line " + lineNumber + " column " + columnNumber + " of the JSON5 data. Still to read: " + JSON.stringify(text.substring(at - 1, at + 19));
+            var where = "the JSON5 data";
+            if( includes.length ) {
+              where = includes[includes.length-1];
+            }
+            error.message = m + " at line " + lineNumber + " column " + columnNumber + " of " + where + ". Still to read: " + JSON.stringify(text.substring(at - 1, at + 19));
             error.at = at;
             // These two property names have been chosen to agree with the ones in Gecko, the only popular
             // environment which seems to supply this info on JSON.parse
@@ -479,24 +484,30 @@ JSON5.parse = (function () {
             if( ch === '@' && inNode ) {
                 next('@');
                 fn = string();
-                var data = fs.readFileSync(fn, 'utf8').toString();
-                var ttext = text,
-                    tat = at,
-                    tlineNumber = lineNumber,
-                    tcolumnNumber = columnNumber,
-                    tch = ch;
-                text = String(data);
-                at = 0;
-                lineNumber = 1;
-                columnNumber = 1;
-                ch = ' ';
-                var v = value();
-                text = ttext;
-                at = tat;
-                lineNumber = tlineNumber;
-                columnNumber = tcolumnNumber;
-                ch = tch;
-                return v;
+                if( includes.indexOf(fn) < 0 ) {
+                    var data = fs.readFileSync(fn, 'utf8').toString();
+                    var ttext = text,
+                        tat = at,
+                        tlineNumber = lineNumber,
+                        tcolumnNumber = columnNumber,
+                        tch = ch;
+                    includes.push(fn);
+                    text = String(data);
+                    at = 0;
+                    lineNumber = 1;
+                    columnNumber = 1;
+                    ch = ' ';
+                    var v = value();
+                    text = ttext;
+                    at = tat;
+                    lineNumber = tlineNumber;
+                    columnNumber = tcolumnNumber;
+                    ch = tch;
+                    includes.pop();
+                    return v;
+                } else {
+                  error('Recursive Include');
+                }
             }
             error("Bad include");
         };

--- a/lib/json5.js
+++ b/lib/json5.js
@@ -6,8 +6,11 @@
 
 var JSON5 = (typeof exports === 'object' ? exports : {});
 
+var inNode = (typeof module !== 'undefined' && module.exports);
+
 JSON5.parse = (function () {
     "use strict";
+    var fs = inNode?require('fs'):null;
 
 // This is a function that can parse a JSON5 text, producing a JavaScript
 // data structure. It is a simple, recursive descent parser. It does not use
@@ -469,8 +472,34 @@ JSON5.parse = (function () {
                 }
             }
             error("Bad object");
-        };
+        },
 
+        include = function() {
+            var fn;
+            if( ch === '@' && inNode ) {
+                next('@');
+                fn = string();
+                var data = fs.readFileSync(fn, 'utf8').toString();
+                var ttext = text,
+                    tat = at,
+                    tlineNumber = lineNumber,
+                    tcolumnNumber = columnNumber,
+                    tch = ch;
+                text = String(data);
+                at = 0;
+                lineNumber = 1;
+                columnNumber = 1;
+                ch = ' ';
+                var v = value();
+                text = ttext;
+                at = tat;
+                lineNumber = tlineNumber;
+                columnNumber = tcolumnNumber;
+                ch = tch;
+                return v;
+            }
+            error("Bad include");
+        };
     value = function () {
 
 // Parse a JSON value. It could be an object, an array, a string, a number,
@@ -478,6 +507,8 @@ JSON5.parse = (function () {
 
         white();
         switch (ch) {
+        case '@':
+            return include();
         case '{':
             return object();
         case '[':


### PR DESCRIPTION
Added the ability to include other JSON5 files via NodeJS.  Syntax @&lt;string of filename>.  .i.e.

newtest.json
`{
  'text': 'text'
}`

test.json
`{
  mydata: @'newtest.json'
}`

so when you JSON5.parse(&lt;string from test.json>) you get

`{
  mydata: {
    'text': 'text'
  }
}`
