### PR TITLE
make package.json5 link in readme a full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ multi-line string',
 }
 ```
 
-This implementation’s own [package.json5](package.json5) is more realistic:
+This implementation’s own [package.json5](https://github.com/json5/json5/blob/master/package.json5) is more realistic:
 
 ```js
 // This file is written in JSON5 syntax, naturally, but npm needs a regular


### PR DESCRIPTION
Currently the link to package.json5 on [json5.org](http://json5.org/#example) is broken. This change ensures the package.json5 link works when the readme is served on either github or json5.org