### PR TITLE
Latest RFC about JSON

### DIFF
--- a/index.md
+++ b/index.md
@@ -14,7 +14,7 @@ parsing and serialization libraries.
 
 [Coverage Status]: https://coveralls.io/github/json5/json5
 
-[JSON]: https://tools.ietf.org/html/rfc7159
+[JSON]: https://tools.ietf.org/html/rfc8259
 
 [ECMAScript 5.1]: https://www.ecma-international.org/ecma-262/5.1/
 


### PR DESCRIPTION
[RFC 7159](https://tools.ietf.org/html/rfc7159) is obsoleted by [RFC 8259](https://tools.ietf.org/html/rfc8259).