### PR TITLE
RFC: add findPointer function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,12 @@
-const parse = require('./parse')
+const parseModule = require('./parse')
 const stringify = require('./stringify')
 
+const parse = parseModule.parse
+const findPointer = parseModule.find
 const JSON5 = {
     parse,
     stringify,
+    findPointer,
 }
 
 module.exports = JSON5

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -9,8 +9,22 @@ let column
 let token
 let key
 let root
+let pointer
+let findPointer
+let foundLine
+let foundColumn
 
-module.exports = function parse (text, reviver) {
+exports.parse = function (text, reviver) {
+    return startParse(text, reviver, null)
+}
+
+exports.find = function (text, pointer) {
+    startParse(text, null, pointer)
+    if (foundLine === undefined) throw Error('JSON5: path(' + pointer + ') not found')
+    return {'line': foundLine, 'column': foundColumn}
+}
+
+function startParse (text, reviver, pathToFind) {
     source = String(text)
     parseState = 'start'
     stack = []
@@ -20,6 +34,10 @@ module.exports = function parse (text, reviver) {
     token = undefined
     key = undefined
     root = undefined
+    pointer = []
+    findPointer = pathToFind
+    foundLine = undefined
+    foundColumn = undefined
 
     do {
         token = lex()
@@ -971,9 +989,19 @@ function push () {
     } else {
         const parent = stack[stack.length - 1]
         if (Array.isArray(parent)) {
+            if (parent.length > 0) pointer.pop()
+            pointer.push(parent.length.toString())
             parent.push(value)
         } else {
+            pointer.push(key.replace('~', '~0').replace('/', '~1'))
             parent[key] = value
+        }
+        if (findPointer !== null) {
+            const pathStr = '/' + pointer.join('/')
+            if (pathStr === findPointer) {
+                foundLine = line
+                foundColumn = column
+            }
         }
     }
 
@@ -1006,6 +1034,7 @@ function pop () {
     } else if (Array.isArray(current)) {
         parseState = 'afterArrayValue'
     } else {
+        pointer.pop()
         parseState = 'afterPropertyValue'
     }
 }

--- a/test/errors.js
+++ b/test/errors.js
@@ -441,4 +441,17 @@ describe('JSON5', () => {
             })
         })
     })
+    describe('#findPointer()', () => {
+        describe('errors', () => {
+            it('throws when path is not found', () => {
+                assert.throws(() => {
+                    JSON5.findPointer('{a:{b:2}}', 'b')
+                },
+                err => (
+                    err instanceof Error &&
+                    /^JSON5: path\(b\) not found/.test(err.message)
+                ))
+            })
+        })
+    })
 })

--- a/test/parse.js
+++ b/test/parse.js
@@ -312,3 +312,42 @@ t.test('parse(text, reviver)', t => {
 
     t.end()
 })
+
+t.test('findPointer(text, text)', t => {
+    t.equal(
+        JSON5.findPointer('{a:{b:2}}', '/a/b').column,
+        7,
+        'finds pointer column through properties'
+    )
+
+    t.equal(
+        JSON5.findPointer('{a:{b:2}}', '/a/b').line,
+        1,
+        'finds pointer line for single line'
+    )
+
+    t.equal(
+        JSON5.findPointer('{\na:\n{b:2}}', '/a/b').line,
+        3,
+        'finds pointer line for multiline'
+    )
+
+    t.equal(
+        JSON5.findPointer('{a:[1,{b:2}]}', '/a/1').column,
+        7,
+        'finds pointer through arrays'
+    )
+
+    t.equal(
+        JSON5.findPointer('{"a/b":{c:2}}', '/a~1b/c').column,
+        11,
+        'finds pointer and properly escapes slashes'
+    )
+
+    t.equal(
+        JSON5.findPointer('{"a~b":{c:2}}', '/a~0b/c').column,
+        11,
+        'finds pointer and properly escapes tildas'
+    )
+    t.end()
+})


### PR DESCRIPTION
This PR adds a function named findPointer which returns the line and column of a JSON element indicated by a JSON pointer.

This allows applications to synchronize between a JSON5 file and the in-memory data structure. For example, this addresses things like #119 where an application determines there is a logical error in the JSON, but it doesn't have enough data to point the user to a line and column number.

JSON Pointers are specified in [RFC 6901](https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-08).  They are strings that can refer to elements of a JSON document. For example, with a JSON document `{"a":{"b":["c","d"]}}`, the JSON pointer `/a/b/1` would refer to `"d"`.

Tools like [ajv](https://github.com/epoberezkin/ajv) optionally use JSON Pointers to refer to the location where schema validation fails. To get line/column numbers, it's [recommended](https://github.com/epoberezkin/ajv/issues/763) to use [json-source-map](https://github.com/epoberezkin/json-source-map), which wouldn't work for JSON5.

A slightly more complicated alternative to adding this function would be to dump a json source map like [json-source-map](https://github.com/epoberezkin/json-source-map) does. json-source-map additionally spits out the string position of the element and if it's an object, it spits out the key end, value start and value end. That additional information would be enough to address #177, because you could easily find a position to insert additional elements into without disturbing comments or whitespace. I don't believe the format that this tool used is standardized but it seems well thought out.

Another complicated alternative is to dump a javascript source map, so you could use json-source-map along with the emitted javascript source map to find the original line and column number of each symbol.

Another alternative is to fork JSON5 to make a separate tool that can find pointers, but we would have to keep the two parsers in sync, otherwise the in-memory data structure won't match the JSON5 pointers.

So I think this is the easiest way to solve the problem, but I'm open to working on building the entire json source map like json-source-map does.