### PR TITLE
Use Object.defineProperty

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -973,7 +973,12 @@ function push () {
         if (Array.isArray(parent)) {
             parent.push(value)
         } else {
-            parent[key] = value
+            Object.defineProperty(parent, key, {
+                configurable: true,
+                enumerable: true,
+                writable: true,
+                value,
+            })
         }
     }
 

--- a/test/parse.js
+++ b/test/parse.js
@@ -51,6 +51,13 @@ t.test('parse(text)', t => {
         )
 
         t.strictSame(
+            // eslint-disable-next-line no-proto
+            JSON5.parse('{"__proto__":1}').__proto__,
+            1,
+            'preserves __proto__ property names'
+        )
+
+        t.strictSame(
             JSON5.parse('{abc:1,def:2}'),
             {abc: 1, def: 2},
             'parses multiple properties'


### PR DESCRIPTION
Properties should be set with `Object.defineProperty` to maintain backward compatibility with `JSON.parse`.

Currently JSON5 exhibits the following behavior.

```js
    JSON.parse(`{"__proto__": 1}`)
//  {__proto__: 1}
    JSON5.parse(`{"__proto__": 1}`)
//  {}
```

However, when JSON5 uses `Object.defineProperty` instead of `object[key] = value` to set the properties of objects, it maintains backward compatibility.

Fixes #199