### PR TITLE
Add module entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "JSON for humans.",
   "main": "lib/index.js",
+  "module": "dist/index.mjs",
   "bin": "lib/cli.js",
   "browser": "dist/index.js",
   "files": [


### PR DESCRIPTION
This PR allows bundlers like `webpack`, `rollup` and `parcel` to take advantage of the es-module build.