### PR TITLE
fix: stringify `\0` as `\\x00` in some cases

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -124,13 +124,20 @@ module.exports = function stringify (value, replacer, space) {
 
         let product = ''
 
-        for (const c of value) {
+        for (let i = 0; i < value.length; i++) {
+            const c = value[i]
             switch (c) {
             case "'":
             case '"':
                 quotes[c]++
                 product += c
                 continue
+
+            case '\0':
+                if (util.isDigit(value[i + 1])) {
+                    product += '\\x00'
+                    continue
+                }
             }
 
             if (replacements[c]) {

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -38,6 +38,10 @@ describe('JSON5', () => {
                 assert.strictEqual(JSON5.stringify({'\\\b\f\n\r\t\v\0\x01': 1}), "{'\\\\\\b\\f\\n\\r\\t\\v\\0\\x01':1}")
             })
 
+            it('stringifies escaped null character property names', () => {
+                assert.strictEqual(JSON5.stringify({'\0\x001': 1}), "{'\\0\\x001':1}")
+            })
+
             it('stringifies multiple properties', () => {
                 assert.strictEqual(JSON5.stringify({abc: 1, def: 2}), '{abc:1,def:2}')
             })
@@ -127,6 +131,10 @@ describe('JSON5', () => {
 
             it('stringifies escaped characters', () => {
                 assert.strictEqual(JSON5.stringify('\\\b\f\n\r\t\v\0\x0f'), "'\\\\\\b\\f\\n\\r\\t\\v\\0\\x0f'")
+            })
+
+            it('stringifies escaped null characters', () => {
+                assert.strictEqual(JSON5.stringify('\0\x001'), "'\\0\\x001'")
             })
 
             it('stringifies escaped single quotes', () => {


### PR DESCRIPTION
The following is invalid JSON5 and ES5 because a digit cannot follow a
null character escape.

    '\01'

However, JSON5 stringifies `'\x001'` as `'\01'` making it impossible to
round trip. This commit ensures that JSON5 stringifies null characters
as `\x00` when followed by a digit.