### PR TITLE
minimist library updated to the latest version (1.2.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,9 +2182,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minipass": {
       "version": "2.3.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "homepage": "http://json5.org/",
   "dependencies": {
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.5"
   },
   "devDependencies": {
     "core-js": "^2.6.5",


### PR DESCRIPTION
The version of minimist used in the project contains a vulnerability fixed in the newer version.
https://app.snyk.io/test/npm/minimist/1.2.0

This change updates the dependency.
