### PR TITLE
Fix OOM when parsing bare hexadecimal literal.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,11 +2,11 @@ const unicode = require('../lib/unicode')
 
 module.exports = {
     isSpaceSeparator (c) {
-        return unicode.Space_Separator.test(c)
+        return typeof c === 'string' && unicode.Space_Separator.test(c)
     },
 
     isIdStartChar (c) {
-        return (
+        return typeof c === 'string' && (
             (c >= 'a' && c <= 'z') ||
         (c >= 'A' && c <= 'Z') ||
         (c === '$') || (c === '_') ||
@@ -15,7 +15,7 @@ module.exports = {
     },
 
     isIdContinueChar (c) {
-        return (
+        return typeof c === 'string' && (
             (c >= 'a' && c <= 'z') ||
         (c >= 'A' && c <= 'Z') ||
         (c >= '0' && c <= '9') ||
@@ -26,10 +26,10 @@ module.exports = {
     },
 
     isDigit (c) {
-        return /[0-9]/.test(c)
+        return typeof c === 'string' && /[0-9]/.test(c)
     },
 
     isHexDigit (c) {
-        return /[0-9A-Fa-f]/.test(c)
+        return typeof c === 'string' && /[0-9A-Fa-f]/.test(c)
     },
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -178,6 +178,30 @@ t.test('parse(text)', t => {
             'parses signed NaN'
         )
 
+        t.strictSame(
+            JSON5.parse('1'),
+            1,
+            'parses 1'
+        )
+
+        t.strictSame(
+            JSON5.parse('+1.23e100'),
+            1.23e100,
+            'parses +1.23e100'
+        )
+
+        t.strictSame(
+            JSON5.parse('0x1'),
+            0x1,
+            'parses bare hexadecimal number'
+        )
+
+        t.strictSame(
+            JSON5.parse('-0x0123456789abcdefABCDEF'),
+            -0x0123456789abcdefABCDEF,
+            'parses bare long hexadecimal number'
+        )
+
         t.end()
     })
 


### PR DESCRIPTION
When parsing a bare hexadecimal number like `JSON5.parse('0x1')`, the parser was looping forever [here](https://github.com/json5/json5/blob/v2.1.2/lib/parse.js#L540-L543) because it was reading to the end and `util.isHexDigit(undefined) === true`.

I updated all of the `util.is*` functions to return `false` for `undefined` and added some regression tests.

Fixes #228.