### PR TITLE
Update minimist version on v1 branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1320,7 +1320,7 @@
         "js-yaml": "3.10.0",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.7",
-        "minimist": "1.2.0",
+        "minimist": "1.2.5",
         "request": "2.83.0"
       }
     },
@@ -3893,9 +3893,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mixin-deep": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "http://json5.org/",
   "dependencies": {
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.3"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
I need v1 of this package, but it's not secure because `minimist` < `1.2.3` is vulnerable. This commit fixes that vulnerability.