### PR TITLE
fix: use named exports for ESM

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,5 @@
 const parse = require('./parse')
 const stringify = require('./stringify')
 
-const JSON5 = {
-    parse,
-    stringify,
-}
-
-module.exports = JSON5
+exports.parse = parse
+exports.stringify = stringify


### PR DESCRIPTION
Uses named exports (along with the existing default export) for the ESM version of JSON5.

Fixes #240