### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        node: ['14', '16', '18']
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '${{ matrix.node }}'
+          cache: npm
+      - run: npm install
+      - run: npm test
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: npm
+      - run: npm install
+      - run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "11"
-  - "10"
-  - "8"
-  - "6"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # JSON5 – JSON for Humans
 
-[![Build Status](https://travis-ci.com/json5/json5.svg)][Build Status]
-[![Coverage
-Status](https://coveralls.io/repos/github/json5/json5/badge.svg)][Coverage
-Status]
+[![Build Status](https://github.com/json5/json5/actions/workflows/ci.yml/badge.svg)][Build Status]
+[![Coverage Status](https://coveralls.io/repos/github/json5/json5/badge.svg)][Coverage Status]
 
 The JSON5 Data Interchange Format (JSON5) is a superset of [JSON] that aims to
 alleviate some of the limitations of JSON by expanding its syntax to include
@@ -12,7 +10,7 @@ some productions from [ECMAScript 5.1].
 This JavaScript library is the official reference implementation for JSON5
 parsing and serialization libraries.
 
-[Build Status]: https://travis-ci.com/json5/json5
+[Build Status]: https://github.com/json5/json5/actions/workflows/ci.yml
 
 [Coverage Status]: https://coveralls.io/github/json5/json5
 


### PR DESCRIPTION
[Travis CI workflow is no longer working](https://github.com/rhysd/json5/actions/runs/2438401038). This PR replaces it with GitHub Actions CI workflow.

The CI workflow checks:

- `npm test` with all Node.js LTS releases (v14, v16, v18)
- `npm run lint`

Here is an example of workflow result: https://github.com/rhysd/json5/actions/runs/2438401038