### PR TITLE
Update Travis CI badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JSON5 – JSON for Humans
 
-[![Build Status](https://api.travis-ci.com/json5/json5.svg?branch=master)][Build Status]
-[![Coverage
+[![Build Status](https://app.travis-ci.com/json5/json5.svg?branch=master)][Build
+Status] [![Coverage
 Status](https://coveralls.io/repos/github/json5/json5/badge.svg)][Coverage
 Status]
 
@@ -12,7 +12,7 @@ some productions from [ECMAScript 5.1].
 This JavaScript library is the official reference implementation for JSON5
 parsing and serialization libraries.
 
-[Build Status]: https://travis-ci.com/json5/json5
+[Build Status]: https://app.travis-ci.com/json5/json5
 
 [Coverage Status]: https://coveralls.io/github/json5/json5
 


### PR DESCRIPTION
Update the Travis CI badge and link to point to the canonical URLs.