### PR TITLE
Publish a security policy

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,3 +1,7 @@
+If you are reporting a security vulnerability, please do not submit an issue.
+Instead, follow the guidelines described in our
+[security policy](../blob/main/SECURITY.md).
+
 If you are submitting a bug report because you are receiving an error or because
 this project is incompatible with the [official JSON5 specification][spec],
 please continue.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,6 +1,6 @@
-If you are submitting a bug because you are receiving an error or because this
-project is incompatible with the [official JSON5
-specification][spec], please continue.
+If you are submitting a bug report because you are receiving an error or because
+this project is incompatible with the [official JSON5 specification][spec],
+please continue.
 
 If you are submitting a feature request or code improvement that is compatible
 with the [official JSON5 specification][spec], please continue.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+If you are patching a security vulnerability, please do not submit a pull
+request. Instead, follow the guidelines described in our
+[security policy](../blob/main/SECURITY.md).
+
 If you are submitting a bug fix for an an error or fixing an incompatibility
 with the [official JSON5 specification][spec], please continue.
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,10 @@ that compatibility is a fundamental premise of JSON5.
 To report bugs or request features regarding this **JavaScript implementation**
 of JSON5, please submit an issue to **_this_ repository**.
 
+### Security Vulnerabilities and Disclosures
+To report a security vulnerability, please follow the follow the guidelines
+described in our [security policy](./SECURITY.md).
+
 ## License
 MIT. See [LICENSE.md](./LICENSE.md) for details.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# JSON5 Security Policy
+
+We take security seriously. Responsible reporting and disclosure of security
+vulnerabilities is important for the protection and privacy of our users. If you
+discover any security vulnerabilities, please follow these guidelines.
+
+To report a vulnerability, we recommend submitting a report to Snyk using their
+[vulnerability disclosure form](https://snyk.io/vulnerability-disclosure/).
+Snyk's security team will validate the vulnerability and coordinate with you and
+us to fix it, release a patch, and responsibly disclose the vulnerability. Read
+Snyk's
+[Vulnerability Disclosure Policy](https://docs.snyk.io/more-info/disclosing-vulnerabilities/disclose-a-vulnerability-in-an-open-source-package)
+for details.
+
+We also request that you send an email to
+[security@json5.org](mailto:security@json5.org) detailing the vulnerability.
+This ensures that we can begin work on a fix as soon as possible without waiting
+for Snyk to contact us.
+
+Please do not report undisclosed vulnerabilities on public sites or forums,
+including GitHub issues and pull requests. Reporting vulnerabilities to the
+public could allow attackers to exploit vulnerable applications before we have
+been able to release a patch and before applications have had time to install
+the patch. Once we have released a patch and sufficient time has passed for
+applications to install the patch, we will disclose the vulnerability to the
+public, at which time you will be free to publish details of the vulnerability
+on public sites and forums.
+
+If you have a fix for a security vulnerability, please do not submit a GitHub
+pull request. Instead, report the vulnerability as described in this policy and
+include a potential fix in the report. Once the vulnerability has been verified
+and a disclosure timeline has been decided, we will contact you to see if you
+would like to submit a pull request.
+
+We appreciate your cooperation in helping keep our users safe by following this
+policy.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,18 +4,19 @@ We take security seriously. Responsible reporting and disclosure of security
 vulnerabilities is important for the protection and privacy of our users. If you
 discover any security vulnerabilities, please follow these guidelines.
 
-To report a vulnerability, we recommend submitting a report to Snyk using their
-[vulnerability disclosure form](https://snyk.io/vulnerability-disclosure/).
-Snyk's security team will validate the vulnerability and coordinate with you and
-us to fix it, release a patch, and responsibly disclose the vulnerability. Read
-Snyk's
-[Vulnerability Disclosure Policy](https://docs.snyk.io/more-info/disclosing-vulnerabilities/disclose-a-vulnerability-in-an-open-source-package)
-for details.
+Published security advisories are available on our [GitHub Security Advisories]
+page.
 
-We also request that you send an email to
-[security@json5.org](mailto:security@json5.org) detailing the vulnerability.
-This ensures that we can begin work on a fix as soon as possible without waiting
-for Snyk to contact us.
+To report a vulnerability, please draft a [new security advisory on GitHub]. Any
+fields that you are unsure of or don't understand can be left at their default
+values. The important part is that the vulnerability is reported. Once the
+security advisory draft has been created, we will validate the vulnerability and
+coordinate with you to fix it, release a patch, and responsibly disclose the
+vulnerability to the public. Read GitHub's documentation on [privately reporting
+a security vulnerability] for details.
+
+If you are unable to draft a security advisory, or if you need help or have
+security related questions, please send an email to [security@json5.org].
 
 Please do not report undisclosed vulnerabilities on public sites or forums,
 including GitHub issues and pull requests. Reporting vulnerabilities to the
@@ -27,10 +28,18 @@ public, at which time you will be free to publish details of the vulnerability
 on public sites and forums.
 
 If you have a fix for a security vulnerability, please do not submit a GitHub
-pull request. Instead, report the vulnerability as described in this policy and
-include a potential fix in the report. Once the vulnerability has been verified
-and a disclosure timeline has been decided, we will contact you to see if you
-would like to submit a pull request.
+pull request. Instead, report the vulnerability as described in this policy.
+Once we have verified the vulnerability, we can create a [temporary private
+fork] to collaborate on a patch.
 
 We appreciate your cooperation in helping keep our users safe by following this
 policy.
+
+[github security advisories]: https://github.com/json5/json5/security/advisories
+[new security advisory on github]:
+  https://github.com/json5/json5/security/advisories/new
+[privately reporting a security vulnerability]:
+  https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
+[security@json5.org]: mailto:security@json5.org
+[temporary private fork]:
+  https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability


### PR DESCRIPTION
This PR publishes a security policy for reporting vulnerabilities as well as linking to it from the README and GitHub issue and pull request templates.

Also fixes a minor typo in the GitHub issue template.