### PR TITLE
Fix syntax highlighting of CLI usage in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ npm install --global json5
 ```
 
 ### Usage
-```sh
+```
 json5 [options] <file>
 ```
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,9 @@ the string. An optional reviver function can be provided to perform a
 transformation on the resulting object before it is returned.
 
 #### Syntax
-    JSON5.parse(text[, reviver])
+```
+JSON5.parse(text[, reviver])
+```
 
 #### Parameters
 - `text`: The string to parse as JSON5.
@@ -156,8 +158,10 @@ replacer function is specified, or optionally including only the specified
 properties if a replacer array is specified.
 
 #### Syntax
-    JSON5.stringify(value[, replacer[, space]])
-    JSON5.stringify(value[, options])
+```
+JSON5.stringify(value[, replacer[, space]])
+JSON5.stringify(value[, options])
+```
 
 #### Parameters
 - `value`: The value to convert to a JSON5 string.


### PR DESCRIPTION
This code block was previously highlighted oddly on the Jekyll site because it does not contain a valid shell script.

Here's what it looks like before this change:

<img width="527" height="99" alt="Screenshot 2026-03-15 at 6 21 40 AM" src="https://github.com/user-attachments/assets/9b5e3229-dfe1-4aad-bc5b-8dbe7ffb1c7d" />

 (Notice the bold `[`).